### PR TITLE
Switch schedule dataset by update date

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@
    {
      "default_base_date": "YYYY-MM-DD",
      "next_base_date": "YYYY-MM-DD",
+     "schedule_update": "YYYY-MM-DD",
      "custom_holidays": ["MM-DD", "MM-DD"],
      "url": "https://bn-k1.github.io/kobancalendar/"
    }
    ```
 
    - `default_base_date`: シフト計算の基準日。
-   - `next_base_date`: コマ位置の入れ替え予定日。next_base_dateを設定することで入れ替え以降のスケジュールを確認できます。設定しなくても動作します。
+   - `next_base_date`: コマ位置の入れ替え予定日。設定しなくても動作します。
+   - `schedule_update`: 交番表データの切り替え日。todayがこの日以降になると`data/next`を使用します。
    - `custom_holidays`: 独自に設定するカスタム祝日の配列。毎年のお盆休みや年末年始の休みなど。
    - `url`にはURLを記述します。QRコードと.icsのPRODID,UIDに使います。
 

--- a/src/composables/useAppInitializer.js
+++ b/src/composables/useAppInitializer.js
@@ -15,8 +15,12 @@ export function useAppInitializer() {
   const isLoaded = ref(false);
 
   const { setEventConfig } = useCalendar();
-  const { loadScheduleData, setDefaultBaseDate, setNextBaseDate } =
-    useSchedule();
+  const {
+    loadScheduleData,
+    setDefaultBaseDate,
+    setNextBaseDate,
+    setScheduleUpdateDate,
+  } = useSchedule();
 
   const { setHolidayYearsRange, setUserDefinedHolidays, loadHolidays } =
     useHolidays();
@@ -50,6 +54,10 @@ export function useAppInitializer() {
       // Process base dates
       const defaultBaseDateObj = createDate(config.default_base_date);
       setDefaultBaseDate(defaultBaseDateObj);
+
+      if (config.schedule_update) {
+        setScheduleUpdateDate(createDate(config.schedule_update));
+      }
 
       // Set next base date if available
       if (config.next_base_date) {

--- a/src/composables/useSchedule.js
+++ b/src/composables/useSchedule.js
@@ -10,6 +10,8 @@ import {
   addDays,
   toUnix,
   isSameDay,
+  today,
+  isSameOrBefore,
 } from "@/utils/date";
 
 /**
@@ -29,15 +31,18 @@ export function useSchedule() {
   const storeDefaultBaseDate = computed(() => scheduleStore.defaultBaseDate);
   const storeActiveBaseDate = computed(() => scheduleStore.activeBaseDate);
   const storeNextBaseDate = computed(() => scheduleStore.nextBaseDate);
+  const storeScheduleUpdateDate = computed(
+    () => scheduleStore.scheduleUpdateDate,
+  );
 
   const storeScheduleData = computed(() => {
-    if (!storeActiveBaseDate.value || !storeNextBaseDate.value) {
+    if (!storeScheduleUpdateDate.value) {
       return storeScheduleDataSets.value.default;
     }
 
-    return isSameDay(storeActiveBaseDate.value, storeNextBaseDate.value)
-      ? storeScheduleDataSets.value.next
-      : storeScheduleDataSets.value.default;
+    return isSameOrBefore(today(), storeScheduleUpdateDate.value)
+      ? storeScheduleDataSets.value.default
+      : storeScheduleDataSets.value.next;
   });
 
   /**
@@ -90,9 +95,7 @@ export function useSchedule() {
       return {};
     }
 
-    const currentScheduleData = isSameDay(baseDate, storeNextBaseDate.value)
-      ? storeScheduleDataSets.value.next
-      : storeScheduleDataSets.value.default;
+    const currentScheduleData = storeScheduleData.value;
 
     // Calculate shift index
     const shiftIndex = calculateShiftIndex(target, startPosition, baseDate);
@@ -232,6 +235,10 @@ export function useSchedule() {
     scheduleStore.setNextBaseDate(createDate(date));
   }
 
+  function setScheduleUpdateDate(date) {
+    scheduleStore.setScheduleUpdateDate(createDate(date));
+  }
+
   return {
     // Computed state from store
     scheduleData: storeScheduleData,
@@ -239,6 +246,7 @@ export function useSchedule() {
     defaultBaseDate: storeDefaultBaseDate,
     activeBaseDate: storeActiveBaseDate,
     nextBaseDate: storeNextBaseDate,
+    scheduleUpdateDate: storeScheduleUpdateDate,
     isDataLoaded: computed(
       () => storeScheduleData.value.rotationCycleLength > 0,
     ),
@@ -254,5 +262,6 @@ export function useSchedule() {
     setDefaultBaseDate,
     updateActiveBaseDate,
     setNextBaseDate,
+    setScheduleUpdateDate,
   };
 }

--- a/src/stores/schedule.js
+++ b/src/stores/schedule.js
@@ -25,6 +25,7 @@ export const useScheduleStore = defineStore("schedule", () => {
   const defaultBaseDate = ref(undefined);
   const activeBaseDate = ref(undefined);
   const nextBaseDate = ref(undefined);
+  const scheduleUpdateDate = ref(undefined);
 
   const isDataLoaded = computed(() => {
     return (
@@ -49,11 +50,16 @@ export const useScheduleStore = defineStore("schedule", () => {
     nextBaseDate.value = date;
   }
 
+  function setScheduleUpdateDate(date) {
+    scheduleUpdateDate.value = date;
+  }
+
   return {
     scheduleDataSets: computed(() => scheduleDataSets.value),
     defaultBaseDate: computed(() => defaultBaseDate.value),
     activeBaseDate: computed(() => activeBaseDate.value),
     nextBaseDate: computed(() => nextBaseDate.value),
+    scheduleUpdateDate: computed(() => scheduleUpdateDate.value),
 
     isDataLoaded,
 
@@ -61,5 +67,6 @@ export const useScheduleStore = defineStore("schedule", () => {
     setDefaultBaseDate,
     updateActiveBaseDate,
     setNextBaseDate,
+    setScheduleUpdateDate,
   };
 });


### PR DESCRIPTION
## Summary
- add `schedule_update` to README instructions
- track schedule update date in schedule store
- load the date during app initialization
- choose schedule dataset based on current date
- keep the sample config unchanged

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: Cannot find module 'papaparse')*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68411acc414c83258c635905b60bc3cf