### PR TITLE
Add schedule update support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,18 @@
    {
      "default_base_date": "YYYY-MM-DD",
      "next_base_date": "YYYY-MM-DD",
+     "schedule_update": "YYYY-MM-DD",
      "custom_holidays": ["MM-DD", "MM-DD"],
      "url": "https://bn-k1.github.io/kobancalendar/"
    }
    ```
 
    - `default_base_date`: シフト計算の基準日。
-   - `next_base_date`: コマ位置の入れ替え予定日。next_base_dateを設定することで入れ替え以降のスケジュールを確認できます。設定しなくても動作します。
-   - `custom_holidays`: 独自に設定するカスタム祝日の配列。毎年のお盆休みや年末年始の休みなど。
-   - `url`にはURLを記述します。QRコードと.icsのPRODID,UIDに使います。
+
+- `next_base_date`: コマ位置の入れ替え予定日。next_base_dateを設定することで入れ替え以降のスケジュールを確認できます。設定しなくても動作します。
+- `schedule_update`: 指定日より後は`data/next`の交番表を自動で使います。省略可。
+- `custom_holidays`: 独自に設定するカスタム祝日の配列。毎年のお盆休みや年末年始の休みなど。
+- `url`にはURLを記述します。QRコードと.icsのPRODID,UIDに使います。
 
 4. `data/default`以下の.csv（`weekday.csv`:平日,`saturday.csv`:土曜,`holiday.csv`:日祝）を編集します。
 

--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,6 @@
 {
   "default_base_date": "2025-05-16",
+  "schedule_update": "2025-06-01",
   "custom_holidays": [
     "08-13",
     "08-14",

--- a/src/composables/useAppInitializer.js
+++ b/src/composables/useAppInitializer.js
@@ -15,8 +15,12 @@ export function useAppInitializer() {
   const isLoaded = ref(false);
 
   const { setEventConfig } = useCalendar();
-  const { loadScheduleData, setDefaultBaseDate, setNextBaseDate } =
-    useSchedule();
+  const {
+    loadScheduleData,
+    setDefaultBaseDate,
+    setNextBaseDate,
+    setScheduleUpdateDate,
+  } = useSchedule();
 
   const { setHolidayYearsRange, setUserDefinedHolidays, loadHolidays } =
     useHolidays();
@@ -58,6 +62,11 @@ export function useAppInitializer() {
       } else {
         // If no next_base_date, use default_base_date
         setNextBaseDate([]);
+      }
+
+      if (config.schedule_update) {
+        const updateDateObj = createDate(config.schedule_update);
+        setScheduleUpdateDate(updateDateObj);
       }
 
       isLoaded.value = true;

--- a/src/composables/useSchedule.js
+++ b/src/composables/useSchedule.js
@@ -10,6 +10,8 @@ import {
   addDays,
   toUnix,
   isSameDay,
+  today,
+  isSameOrBefore,
 } from "@/utils/date";
 
 /**
@@ -29,8 +31,17 @@ export function useSchedule() {
   const storeDefaultBaseDate = computed(() => scheduleStore.defaultBaseDate);
   const storeActiveBaseDate = computed(() => scheduleStore.activeBaseDate);
   const storeNextBaseDate = computed(() => scheduleStore.nextBaseDate);
+  const storeScheduleUpdateDate = computed(
+    () => scheduleStore.scheduleUpdateDate,
+  );
 
   const storeScheduleData = computed(() => {
+    if (storeScheduleUpdateDate.value) {
+      return isSameOrBefore(today(), storeScheduleUpdateDate.value)
+        ? storeScheduleDataSets.value.default
+        : storeScheduleDataSets.value.next;
+    }
+
     if (!storeActiveBaseDate.value || !storeNextBaseDate.value) {
       return storeScheduleDataSets.value.default;
     }
@@ -90,9 +101,19 @@ export function useSchedule() {
       return {};
     }
 
-    const currentScheduleData = isSameDay(baseDate, storeNextBaseDate.value)
-      ? storeScheduleDataSets.value.next
-      : storeScheduleDataSets.value.default;
+    let currentScheduleData;
+    if (storeScheduleUpdateDate.value) {
+      currentScheduleData = isSameOrBefore(
+        today(),
+        storeScheduleUpdateDate.value,
+      )
+        ? storeScheduleDataSets.value.default
+        : storeScheduleDataSets.value.next;
+    } else {
+      currentScheduleData = isSameDay(baseDate, storeNextBaseDate.value)
+        ? storeScheduleDataSets.value.next
+        : storeScheduleDataSets.value.default;
+    }
 
     // Calculate shift index
     const shiftIndex = calculateShiftIndex(target, startPosition, baseDate);
@@ -232,6 +253,10 @@ export function useSchedule() {
     scheduleStore.setNextBaseDate(createDate(date));
   }
 
+  function setScheduleUpdateDate(date) {
+    scheduleStore.setScheduleUpdateDate(createDate(date));
+  }
+
   return {
     // Computed state from store
     scheduleData: storeScheduleData,
@@ -239,6 +264,7 @@ export function useSchedule() {
     defaultBaseDate: storeDefaultBaseDate,
     activeBaseDate: storeActiveBaseDate,
     nextBaseDate: storeNextBaseDate,
+    scheduleUpdateDate: storeScheduleUpdateDate,
     isDataLoaded: computed(
       () => storeScheduleData.value.rotationCycleLength > 0,
     ),
@@ -254,5 +280,6 @@ export function useSchedule() {
     setDefaultBaseDate,
     updateActiveBaseDate,
     setNextBaseDate,
+    setScheduleUpdateDate,
   };
 }

--- a/src/stores/schedule.js
+++ b/src/stores/schedule.js
@@ -25,6 +25,7 @@ export const useScheduleStore = defineStore("schedule", () => {
   const defaultBaseDate = ref(undefined);
   const activeBaseDate = ref(undefined);
   const nextBaseDate = ref(undefined);
+  const scheduleUpdateDate = ref(undefined);
 
   const isDataLoaded = computed(() => {
     return (
@@ -49,11 +50,16 @@ export const useScheduleStore = defineStore("schedule", () => {
     nextBaseDate.value = date;
   }
 
+  function setScheduleUpdateDate(date) {
+    scheduleUpdateDate.value = date;
+  }
+
   return {
     scheduleDataSets: computed(() => scheduleDataSets.value),
     defaultBaseDate: computed(() => defaultBaseDate.value),
     activeBaseDate: computed(() => activeBaseDate.value),
     nextBaseDate: computed(() => nextBaseDate.value),
+    scheduleUpdateDate: computed(() => scheduleUpdateDate.value),
 
     isDataLoaded,
 
@@ -61,5 +67,6 @@ export const useScheduleStore = defineStore("schedule", () => {
     setDefaultBaseDate,
     updateActiveBaseDate,
     setNextBaseDate,
+    setScheduleUpdateDate,
   };
 });


### PR DESCRIPTION
## Summary
- add `schedule_update` to config
- document new field in README
- store schedule update date in the schedule store
- switch schedule datasets by `schedule_update` in useSchedule
- load `schedule_update` in initializer

## Testing
- `npm run build` *(fails: Cannot find module 'papaparse')*

------
https://chatgpt.com/codex/tasks/task_e_684235c1ef6883258d5e5c1c53c9ab29